### PR TITLE
5 GHz channel steering for dual-band adapters

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 14
-        versionName = "1.2.8"
+        versionCode = 15
+        versionName = "1.2.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 16
-        versionName = "1.2.10"
+        versionCode = 17
+        versionName = "1.2.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 11
-        versionName = "1.2.5"
+        versionCode = 12
+        versionName = "1.2.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 12
-        versionName = "1.2.6"
+        versionCode = 13
+        versionName = "1.2.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 15
-        versionName = "1.2.9"
+        versionCode = 16
+        versionName = "1.2.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 13
-        versionName = "1.2.7"
+        versionCode = 14
+        versionName = "1.2.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 17
-        versionName = "1.2.11"
+        versionCode = 18
+        versionName = "1.2.12"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.wsvdmeer.pwncompanion"
         minSdk = 29
         targetSdk = 36
-        versionCode = 10
-        versionName = "1.2.4"
+        versionCode = 11
+        versionName = "1.2.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Native cracker (libwpacrack.so) — small PBKDF2 kernel for on-phone cracking. arm64 is

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/models/DeviceState.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/models/DeviceState.kt
@@ -24,6 +24,8 @@ data class DeviceState(
     val autotuneChannels: Map<String, AutotuneChannelStat>? = null,
     val autotuneBestChannel: Int? = null,
     val autotuneMinRssi: Int? = null,
+    /** Channels the device's monitor iface supports (reg-domain aware); null = unknown. */
+    val supportedChannels: List<Int>? = null,
     /** Geolocated handshakes captured by the device (newest first). */
     val captures: List<CaptureEntry> = emptyList(),
     /** Latest per-epoch telemetry (vitals, reward, mood counters). */

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/models/ScreenData.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/models/ScreenData.kt
@@ -117,6 +117,12 @@ data class ScreenData(
     @SerialName("autotune_min_rssi")
     val autotuneMinRssi: Int? = null,
 
+    // The channels the device's monitor interface actually supports (reg-domain aware).
+    // Lets the steering bandit discover 5 GHz on dual-band adapters instead of a
+    // hardcoded 2.4 GHz list. Null on older plugins → app falls back to the 2.4 floor.
+    @SerialName("supported_channels")
+    val supportedChannels: List<Int>? = null,
+
     // Whether the device's wpa-sec cracking plugin is enabled + downloading results
     // (reported in status messages), so the app can flag if cracking is actually on.
     @SerialName("wpa_sec_enabled")  val wpaSecEnabled: Boolean? = null,

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/models/ScreenData.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/models/ScreenData.kt
@@ -216,9 +216,14 @@ data class CaptureEntry(
     // hashcat-22000 line (WPA*01 PMKID / WPA*02 EAPOL) from the plugin's hcxpcapngtool, for
     // on-phone cracking. Null when the grab isn't crackable or the tool was unavailable.
     @SerialName("hash22000") val hash22000: String? = null,
+    // The AP's channel, from the plugin (on_handshake / gps sidecar). Null = unknown
+    // (older plugin, or a pre-channel capture) — the band tag is just hidden then.
+    @SerialName("channel")   val channel: Int? = null,
 ) {
     /** Stable identity for de-duping across reconnects / live appends. */
     val key: String get() = if (bssid.isNotBlank()) bssid else "$ssid@$timestamp"
+    /** Radio band derived from the channel: "2.4" | "5" | null when unknown. */
+    val band: String? get() = channel?.let { if (it in 1..14) "2.4" else if (it >= 36) "5" else null }
     val isGeolocated: Boolean get() = latitude != null && longitude != null
     /** True when the capture yields a crackable hash (PMKID or full EAPOL). */
     val isCrackable: Boolean get() = quality == "eapol" || quality == "pmkid"

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/MainViewModel.kt
@@ -499,6 +499,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                             ?.toMap()
                             ?: emptyMap()
                     },
+                    // The device's real supported-channel universe (reg-domain aware), so the
+                    // bandit discovers 5 GHz on dual-band adapters. Empty until reported →
+                    // scheduler falls back to the 2.4 GHz floor.
+                    supportedChannels = {
+                        _deviceStates.value.values
+                            .firstOrNull { !it.supportedChannels.isNullOrEmpty() }
+                            ?.supportedChannels
+                            ?.toSet()
+                            ?: emptySet()
+                    },
                     // Only steer while actively hunting — no steering (or logs) in manual.
                     isAutoMode = { _isAutoMode.value },
                     // Channel of the AP seen-often-but-never-caught, so steering can chase it.

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/ui/CapturesDetailScreen.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/ui/CapturesDetailScreen.kt
@@ -432,6 +432,9 @@ private fun CaptureDetailSheet(
             )
             Spacer(Modifier.height(12.dp))
             DetailKv("bssid", capture.bssid.ifBlank { "—" }, dim, onSurface)
+            capture.band?.let { b ->
+                DetailKv("band", "${if (b == "5") "5 GHz" else "2.4 GHz"} · ch ${capture.channel}", dim, onSurface)
+            }
             DetailKv("quality", capture.quality ?: "unknown", dim, onSurface)
             DetailKv(
                 "location",
@@ -801,6 +804,14 @@ private fun CaptureDetailRow(
                     color = dim, fontSize = 10.sp, fontFamily = TerminalMono, maxLines = 1
                 )
             }
+        }
+        // Band tag (2.4/5 GHz) from the capture's channel, when known.
+        c.band?.let { b ->
+            Text(
+                if (b == "5") "5G" else "2.4G",
+                color = if (b == "5") Color(0xFF6EC1FF) else dim,
+                fontSize = 10.sp, fontFamily = TerminalMono, modifier = Modifier.padding(end = 8.dp)
+            )
         }
         // Status tag: cracked > running/queued (on-phone) > ready-to-crack > crackable > partial.
         when {

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/ui/Composables.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/ui/Composables.kt
@@ -856,7 +856,7 @@ private fun ConsoleSteeringBlock(
             val g24 = spectrum.filter { it <= 14 }
             val g5 = spectrum.filter { it > 14 }
             Row(modifier = Modifier.padding(vertical = 2.dp), verticalAlignment = Alignment.CenterVertically) {
-                Text("recon".padEnd(7) + ": ", color = dim, fontSize = 12.sp, lineHeight = 18.sp)
+                Text("chans".padEnd(7) + ": ", color = dim, fontSize = 12.sp, lineHeight = 18.sp)
                 Row(
                     modifier = Modifier.horizontalScroll(rememberScrollState()),
                     horizontalArrangement = Arrangement.spacedBy(2.dp),
@@ -875,7 +875,7 @@ private fun ConsoleSteeringBlock(
         }
         tuning?.let { t ->
             ConsoleBarRow("rssi", rangeFrac(t.minRssi, -90, -55), "${t.minRssi}dBm", primary)
-            ConsoleBarRow("recon", rangeFrac(t.reconTime, 10, 60), "${t.reconTime}s", primary)
+            ConsoleBarRow("dwell", rangeFrac(t.reconTime, 10, 60), "${t.reconTime}s", primary)
             ConsoleBarRow("ap ttl", rangeFrac(t.apTtl, 30, 300), "${t.apTtl}s", dim)
             ConsoleBarRow("sta ttl", rangeFrac(t.staTtl, 60, 600), "${t.staTtl}s", dim)
             ConsoleBarRow("hop", rangeFrac(t.hopRecon, 2, 30), "${t.hopRecon}s", dim)

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/ui/Composables.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/presentation/ui/Composables.kt
@@ -3,6 +3,8 @@ package com.wsvdmeer.pwncompanion.presentation.ui
 import kotlin.math.roundToInt
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -495,7 +497,7 @@ fun MainContentArea(
         // ── steering — live: the channels + params the phone is working right now ──
         if (connectedDevices.isNotEmpty() && (channelPriority.isNotEmpty() || tuning != null)) {
             item {
-                ConsoleSteeringBlock(channelPriority, tuning)
+                ConsoleSteeringBlock(channelPriority, tuning, device?.supportedChannels ?: emptyList())
                 ConsoleRule()
             }
         }
@@ -834,6 +836,7 @@ private fun rangeFrac(v: Int, lo: Int, hi: Int): Float =
 private fun ConsoleSteeringBlock(
     channels: List<Int>,
     tuning: com.wsvdmeer.pwncompanion.models.TuningState?,
+    supportedChannels: List<Int> = emptyList(),
 ) {
     val primary = MaterialTheme.colorScheme.primary
     val dim = MaterialTheme.colorScheme.onSurfaceVariant
@@ -842,15 +845,33 @@ private fun ConsoleSteeringBlock(
         ConsoleLabel("[ steering ]")
         Spacer(modifier = Modifier.height(4.dp))
         if (channels.isNotEmpty()) {
+            // Spectrum across BOTH bands: 2.4 GHz (1–14), a gap, then the 5 GHz channels the
+            // device actually supports — so steered 5 GHz channels light up too, not just 1–11.
+            val spectrum = remember(supportedChannels) {
+                (if (supportedChannels.isNotEmpty()) supportedChannels
+                 else listOf(1,2,3,4,5,6,7,8,9,10,11,12,13,
+                             36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136,140,144,
+                             149,153,157,161,165)).sorted()
+            }
+            val g24 = spectrum.filter { it <= 14 }
+            val g5 = spectrum.filter { it > 14 }
             Row(modifier = Modifier.padding(vertical = 2.dp), verticalAlignment = Alignment.CenterVertically) {
                 Text("recon".padEnd(7) + ": ", color = dim, fontSize = 12.sp, lineHeight = 18.sp)
-                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-                    (1..11).forEach { ch ->
-                        Box(Modifier.size(width = 8.dp, height = 11.dp).background(if (ch in channels) primary else off))
+                Row(
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    g24.forEach { ch ->
+                        Box(Modifier.size(width = 6.dp, height = 11.dp).background(if (ch in channels) primary else off))
+                    }
+                    if (g5.isNotEmpty()) Spacer(Modifier.width(6.dp))
+                    g5.forEach { ch ->
+                        Box(Modifier.size(width = 6.dp, height = 11.dp).background(if (ch in channels) primary else off))
                     }
                 }
-                Text("  ch ${channels.joinToString(",")}", color = primary, fontSize = 12.sp, lineHeight = 18.sp, maxLines = 1)
             }
+            Text("ch ${channels.joinToString(",")}", color = primary, fontSize = 12.sp, lineHeight = 18.sp, maxLines = 1)
         }
         tuning?.let { t ->
             ConsoleBarRow("rssi", rangeFrac(t.minRssi, -90, -55), "${t.minRssi}dBm", primary)

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/NetworkService.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/NetworkService.kt
@@ -457,6 +457,7 @@ class NetworkService(private val context: Context) {
         scope.launch {
             // Merge onto any state a message already created (capture_history can land before this
             // registration coroutine runs) so we set the connection fields without wiping captures.
+            val liveIds = webSocketServer.getConnectedClientIds()
             _deviceStates.update { states ->
                 val base = states[deviceId] ?: DeviceState(
                     deviceId = deviceId, deviceName = deviceName,
@@ -470,7 +471,14 @@ class NetworkService(private val context: Context) {
                     isConnected = true,
                     connectionState = DeviceState.ConnectionState.CONNECTED,
                 )
-                states.toMutableMap().apply { put(deviceId, state) }
+                // Reconcile so a reconnect (which arrives under a NEW session id) can't leave a
+                // stale twin behind — the "2 nodes online" / flipping-image bug. Keep only
+                // entries whose socket is still live AND that aren't the same physical device
+                // (same IP) as the one just (re)connecting; then add the fresh state.
+                states.filterKeys { it in liveIds }
+                    .filterValues { it.ipAddress != clientIp }
+                    .toMutableMap()
+                    .apply { put(deviceId, state) }
             }
             _connectedDeviceCount.value = webSocketServer.getConnectedClientCount()
 

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/NetworkService.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/NetworkService.kt
@@ -612,6 +612,7 @@ class NetworkService(private val context: Context) {
                     autotuneChannels = data.autotuneChannels ?: currentState.autotuneChannels,
                     autotuneBestChannel = data.autotuneBestChannel ?: currentState.autotuneBestChannel,
                     autotuneMinRssi = data.autotuneMinRssi ?: currentState.autotuneMinRssi,
+                    supportedChannels = data.supportedChannels ?: currentState.supportedChannels,
                     // Merge capture history: the plugin sends the full log on connect and
                     // single-entry appends on each new handshake. Dedupe by key (BSSID),
                     // newest first, keeping the richer (incoming) record on collision.

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
@@ -159,17 +159,29 @@ class SyncScheduler(
                 return
             }
 
-            // ── Device ground truth: autotune per-channel stats ───────────────────
-            // The pwnagotchi's own per-channel tally: handshakes landed AND live client
-            // density (sta). Clients are the deauth targets, so a channel busy with
-            // clients right now is a fresh opportunity, not just where old handshakes fell.
+            // ── Device signals (best-effort, NOT preconditions) ───────────────────
+            // autotune = the plugin's per-channel handshake/client tally. On modern
+            // pwnagotchi (>= 2.9.5.5, "strategy" core) epoch_data carries no channel, so
+            // this stays empty — treat it as a bonus when present, never a gate.
             val auto = autotuneStats()
             val hasAuto = auto.values.any { it.handshakes > 0 || it.sta > 0 }
 
             val stats = memoryService.getLearningStats()
             val haveLearning = stats.totalObservations >= minObservationsToSteer
-            if (!haveLearning && !hasAuto) {
-                Log.d(tag, "Only ${stats.totalObservations} observations and no autotune data — not steering yet")
+
+            // Candidate universe: the channels the DEVICE actually supports (authoritative,
+            // reg-domain aware) so dual-band adapters' 5 GHz channels are discoverable — not
+            // a hardcoded 2.4 GHz list. Fall back to the 2.4 floor until the device reports.
+            val supported = supportedChannels().filter { it in 1..165 }.toSet()
+            val discoveryBase = supported.ifEmpty { (1..11).toSet() }
+
+            // Cold start: with no learned yield AND no autotune (the norm on new pwnagotchi,
+            // where autotune never populates), don't sit idle — fall through to a pure-
+            // exploration steer across the supported channels so recon covers both bands from
+            // cycle one and the learning DB starts filling. Only bail if there's genuinely
+            // nothing to explore.
+            if (!haveLearning && !hasAuto && discoveryBase.isEmpty()) {
+                Log.d(tag, "no learning, no autotune, no channel list — not steering yet")
                 return
             }
 
@@ -208,12 +220,8 @@ class SyncScheduler(
                 return s
             }
 
-            // Candidate universe: what the DEVICE actually supports (authoritative and
-            // reg-domain aware) so a dual-band adapter's 5 GHz channels are discoverable —
-            // not a hardcoded 2.4 GHz list. Fall back to the 2.4 floor (1–11) until the
-            // device reports its channels (older plugin / before first telemetry).
-            val supported = supportedChannels().filter { it in 1..165 }.toSet()
-            val discoveryBase = supported.ifEmpty { (1..11).toSet() }
+            // Candidates: the supported-channel discovery base plus everything we know about
+            // (learned yield / here / now / untapped), intersected with what the device can do.
             val candidates = buildSet {
                 addAll(discoveryBase); addAll(auto.keys); addAll(yieldByCh.keys); addAll(hourly); addAll(nearby); untap?.let { add(it) }
             }.filter { it in 1..165 && (supported.isEmpty() || it in supported) }

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
@@ -73,6 +73,10 @@ class SyncScheduler(
     // one instance so its pull memory persists across cycles.
     private val bandit = ChannelBandit()
 
+    // Round-robin cursor for the reserved exploration slot — walks the full supported
+    // spectrum so 5 GHz keeps getting revisited even when 2.4 dominates the exploit score.
+    private var exploreIdx = 0
+
     // ── Personality tuner (re-implements jayofelony's removed RL param-tuner) ──
     // Context policy: ap_ttl/sta_ttl/hop set from motion. Feedback hill-climb: min_rssi
     // nudged every RSSI_WINDOW toward whatever raises the capture rate. Per-key idle
@@ -226,15 +230,27 @@ class SyncScheduler(
                 addAll(discoveryBase); addAll(auto.keys); addAll(yieldByCh.keys); addAll(hourly); addAll(nearby); untap?.let { add(it) }
             }.filter { it in 1..165 && (supported.isEmpty() || it in supported) }
 
-            // UCB1 (pure, in ChannelBandit): normalised exploit + an exploration bonus that's
-            // large for under-sampled channels and shrinks as we sample them; decaying pulls
-            // make it re-explore over time. With the newly-supported 5 GHz channels now in the
-            // candidate pool, UCB handles band balance on its own: a fresh 5 GHz arm outscores
-            // even a constantly-picked 2.4 channel (whose exploration bonus has shrunk), so it
-            // gets sampled; if the band is dead it decays away, and pull-decay re-checks it
-            // periodically. No separate band-diversity guard needed (it would just waste hops
-            // in genuinely 2.4-only areas).
-            val topChannels = bandit.select(candidates, 3) { exploit(it) }
+            // Two EXPLOIT slots via UCB1 (goes where the clients/handshakes are — usually 2.4,
+            // since that's where real per-channel yield lives now that ground truth is restored).
+            val exploitTop = bandit.select(candidates, 2) { exploit(it) }
+
+            // One RESERVED EXPLORE slot: round-robin across the full supported spectrum so every
+            // channel — crucially 5 GHz — keeps getting revisited even when dense-2.4 exploit would
+            // otherwise starve it. This breaks the chicken-and-egg (can't earn 5 GHz yield without
+            // ever hunting 5 GHz). If a 5 GHz channel does start yielding, it also wins exploit slots.
+            val sortedCand = candidates.sorted()
+            var exploreCh: Int? = null
+            if (sortedCand.isNotEmpty()) {
+                for (i in sortedCand.indices) {
+                    val c = sortedCand[(exploreIdx + i) % sortedCand.size]
+                    if (c !in exploitTop) {
+                        exploreCh = c
+                        exploreIdx = (exploreIdx + i + 1) % sortedCand.size
+                        break
+                    }
+                }
+            }
+            val topChannels = (exploitTop + listOfNotNull(exploreCh)).distinct()
             if (topChannels.isEmpty()) return
 
             // Per-cycle trace so behaviour is observable live in AUTO (adb logcat -s SyncScheduler:D):

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
@@ -28,6 +28,11 @@ class SyncScheduler(
     // pwnagotchi itself and doesn't depend on the app having logged events while
     // connected. Keyed by channel number. Empty when no autotune data has arrived.
     private val autotuneStats: () -> Map<Int, com.wsvdmeer.pwncompanion.models.AutotuneChannelStat> = { emptyMap() },
+    // The channels the device's monitor interface actually supports (reg-domain aware,
+    // reported by the plugin). This is the authoritative candidate universe for steering,
+    // so a dual-band adapter's 5 GHz channels are discoverable instead of a hardcoded 2.4
+    // list. Empty when unknown (older plugin / before first report) → 2.4 GHz floor fallback.
+    private val supportedChannels: () -> Set<Int> = { emptySet() },
     // Whether the device is actively hunting (AUTO). In MANUAL the device isn't
     // scanning, so steering its recon is pointless — we skip it entirely (no command,
     // no log spam) until the user goes back to AUTO.
@@ -203,15 +208,24 @@ class SyncScheduler(
                 return s
             }
 
-            // Candidates: everything we know about PLUS the 2.4GHz floor (1–11) so the
-            // bandit can explore channels we've seen no activity on yet (discovery).
+            // Candidate universe: what the DEVICE actually supports (authoritative and
+            // reg-domain aware) so a dual-band adapter's 5 GHz channels are discoverable —
+            // not a hardcoded 2.4 GHz list. Fall back to the 2.4 floor (1–11) until the
+            // device reports its channels (older plugin / before first telemetry).
+            val supported = supportedChannels().filter { it in 1..165 }.toSet()
+            val discoveryBase = supported.ifEmpty { (1..11).toSet() }
             val candidates = buildSet {
-                addAll(1..11); addAll(auto.keys); addAll(yieldByCh.keys); addAll(hourly); addAll(nearby); untap?.let { add(it) }
-            }.filter { it in 1..165 }
+                addAll(discoveryBase); addAll(auto.keys); addAll(yieldByCh.keys); addAll(hourly); addAll(nearby); untap?.let { add(it) }
+            }.filter { it in 1..165 && (supported.isEmpty() || it in supported) }
 
             // UCB1 (pure, in ChannelBandit): normalised exploit + an exploration bonus that's
             // large for under-sampled channels and shrinks as we sample them; decaying pulls
-            // make it re-explore over time.
+            // make it re-explore over time. With the newly-supported 5 GHz channels now in the
+            // candidate pool, UCB handles band balance on its own: a fresh 5 GHz arm outscores
+            // even a constantly-picked 2.4 channel (whose exploration bonus has shrunk), so it
+            // gets sampled; if the band is dead it decays away, and pull-decay re-checks it
+            // periodically. No separate band-diversity guard needed (it would just waste hops
+            // in genuinely 2.4-only areas).
             val topChannels = bandit.select(candidates, 3) { exploit(it) }
             if (topChannels.isEmpty()) return
 

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
@@ -234,18 +234,29 @@ class SyncScheduler(
             // since that's where real per-channel yield lives now that ground truth is restored).
             val exploitTop = bandit.select(candidates, 2) { exploit(it) }
 
-            // One RESERVED EXPLORE slot: round-robin across the full supported spectrum so every
-            // channel — crucially 5 GHz — keeps getting revisited even when dense-2.4 exploit would
-            // otherwise starve it. This breaks the chicken-and-egg (can't earn 5 GHz yield without
-            // ever hunting 5 GHz). If a 5 GHz channel does start yielding, it also wins exploit slots.
+            // One RESERVED EXPLORE slot, rotating through the band the exploit slots are NOT
+            // covering. Clients (hence exploit) live on 2.4, so this keeps the 3rd slot on 5 GHz
+            // — hunting 5 GHz EVERY cycle instead of only after walking all of 2.4 first. Breaks
+            // the chicken-and-egg (can't earn 5 GHz yield without ever hunting 5 GHz); a yielding
+            // 5 GHz channel still also wins exploit slots. Falls back to the whole spectrum if the
+            // device is single-band.
             val sortedCand = candidates.sorted()
+            val band24 = sortedCand.filter { it <= 14 }
+            val band5 = sortedCand.filter { it > 14 }
+            val exploit5 = exploitTop.count { it > 14 }
+            val exploit24 = exploitTop.size - exploit5
+            val pool = when {
+                exploit24 >= exploit5 && band5.isNotEmpty() -> band5   // exploit leans 2.4 → explore 5 GHz
+                band24.isNotEmpty() -> band24                          // exploit leans 5 GHz → explore 2.4
+                else -> sortedCand
+            }
             var exploreCh: Int? = null
-            if (sortedCand.isNotEmpty()) {
-                for (i in sortedCand.indices) {
-                    val c = sortedCand[(exploreIdx + i) % sortedCand.size]
+            if (pool.isNotEmpty()) {
+                for (i in pool.indices) {
+                    val c = pool[(exploreIdx + i) % pool.size]
                     if (c !in exploitTop) {
                         exploreCh = c
-                        exploreIdx = (exploreIdx + i + 1) % sortedCand.size
+                        exploreIdx = (exploreIdx + i + 1) % pool.size
                         break
                     }
                 }

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/SyncScheduler.kt
@@ -226,9 +226,13 @@ class SyncScheduler(
 
             // Candidates: the supported-channel discovery base plus everything we know about
             // (learned yield / here / now / untapped), intersected with what the device can do.
+            // EXCLUDE DFS 5 GHz channels (UNII-2): the dongle can't actively operate there without
+            // radar clearance, so steering onto them stalls recon ("blind") — and they're useless
+            // for pwning (no deauth/injection). Leaves non-DFS 5 GHz (36-48, 149-165) usable.
+            val dfs = setOf(52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144)
             val candidates = buildSet {
                 addAll(discoveryBase); addAll(auto.keys); addAll(yieldByCh.keys); addAll(hourly); addAll(nearby); untap?.let { add(it) }
-            }.filter { it in 1..165 && (supported.isEmpty() || it in supported) }
+            }.filter { it in 1..165 && it !in dfs && (supported.isEmpty() || it in supported) }
 
             // Two EXPLOIT slots via UCB1 (goes where the clients/handshakes are — usually 2.4,
             // since that's where real per-channel yield lives now that ground truth is restored).

--- a/app/src/main/java/com/wsvdmeer/pwncompanion/services/WebSocketServerService.kt
+++ b/app/src/main/java/com/wsvdmeer/pwncompanion/services/WebSocketServerService.kt
@@ -258,6 +258,9 @@ class WebSocketServerService(
      */
     fun getConnectedClientCount(): Int = connectedClients.size
 
+    /** Live socket session ids — used to reconcile device state and evict stale reconnect twins. */
+    fun getConnectedClientIds(): Set<String> = connectedClients.keys.toSet()
+
     /**
      * Get list of connected devices.
      */

--- a/pwn-companion.py
+++ b/pwn-companion.py
@@ -2045,7 +2045,7 @@ class PwnCompanion(Plugin):
         if raw is not None and "value" not in params:
             params = {**params, "value": raw}
 
-        log.info(f"[pwn-companion] Command received: {action}, params: {params}")
+        log.debug(f"[pwn-companion] Command received: {action}, params: {params}")
 
         with self.lock:
             self.last_command = {
@@ -2091,7 +2091,7 @@ class PwnCompanion(Plugin):
             log.warning("[pwn-companion] execute_command: empty action")
             return
 
-        log.info(f"[pwn-companion] ⚙️ Executing command: {action}")
+        log.debug(f"[pwn-companion] ⚙️ Executing command: {action}")
 
         try:
             if action in ("restart_auto", "restart_manual"):
@@ -2252,7 +2252,8 @@ class PwnCompanion(Plugin):
             if accuracy < 0:
                 raise ValueError(f"Invalid accuracy: {accuracy} (must be >= 0)")
 
-            log.info(
+            # GPS arrives every ~1-2s — DEBUG, not INFO, or it drowns the log.
+            log.debug(
                 f"[pwn-companion] ✓ GPS received: {latitude:.{GPS_COORD_PRECISION}f}, {longitude:.{GPS_COORD_PRECISION}f} (±{accuracy:.{ACCURACY_FORMAT_PRECISION}f}m, alt:{altitude:.{ACCURACY_FORMAT_PRECISION}f}m)"
             )
 

--- a/pwn-companion.py
+++ b/pwn-companion.py
@@ -1327,6 +1327,11 @@ class PwnCompanion(Plugin):
                 if rssi is not None:
                     msg["autotune_min_rssi"] = rssi
 
+                # Report the adapter's real supported channels so the app can steer 5 GHz.
+                supported = self._supported_channels(agent)
+                if supported:
+                    msg["supported_channels"] = supported
+
                 self._schedule_on_loop(
                     self._send_to_app(msg),
                     self.loop
@@ -2473,9 +2478,32 @@ class PwnCompanion(Plugin):
             rssi = self._autotune_min_rssi()
             if rssi is not None:
                 msg["autotune_min_rssi"] = rssi
+            supported = self._supported_channels(agent)
+            if supported:
+                msg["supported_channels"] = supported
             await self._send_to_app(msg)
         except Exception as e:
             log.debug(f"[pwn-companion] Error sending autotune stats: {e}")
+
+    def _supported_channels(self, agent):
+        """The monitor interface's supported channels (reg-domain aware), or None.
+
+        pwnagotchi's Agent exposes supported_channels, computed from `iw phy channels`
+        (which already excludes disabled/unavailable channels), so it reflects the real
+        adapter + regulatory domain. Reporting it lets the app's steering bandit discover
+        5 GHz on dual-band dongles instead of a hardcoded 2.4 GHz list. Returns None on
+        older cores / if unavailable, so the app keeps its 2.4 GHz fallback.
+        """
+        try:
+            sc = getattr(agent, "supported_channels", None)
+            if callable(sc):
+                sc = sc()
+            if sc:
+                chans = sorted({int(c) for c in sc if 1 <= int(c) <= 165})
+                return chans or None
+        except Exception:
+            pass
+        return None
 
     def _autotune_min_rssi(self):
         """The channel-tuning plugin's current min_rssi threshold, or None.

--- a/pwn-companion.py
+++ b/pwn-companion.py
@@ -873,6 +873,7 @@ class PwnCompanion(Plugin):
                     "accuracy": self.last_gps.get("accuracy"),
                     "altitude": self.last_gps.get("altitude"),
                     "timestamp": self.last_gps.get("timestamp"),
+                    "channel": ap_channel,   # so a rescan can still show 2.4/5 GHz band
                 }
                 try:
                     with open(gps_filename, "w") as fp:
@@ -896,6 +897,8 @@ class PwnCompanion(Plugin):
                     "bssid": cap_bssid,
                     "timestamp": (self.last_gps.get("timestamp") if has_gps else None) or int(time.time()),
                 }
+                if ap_channel:
+                    entry["channel"] = ap_channel   # lets the app tag this capture 2.4/5 GHz
                 if has_gps:
                     entry["latitude"] = self.last_gps.get("latitude")
                     entry["longitude"] = self.last_gps.get("longitude")
@@ -1149,6 +1152,8 @@ class PwnCompanion(Plugin):
                             entry["accuracy"] = gps.get("accuracy")
                             if gps.get("timestamp"):
                                 entry["timestamp"] = int(gps["timestamp"])
+                        if gps.get("channel"):
+                            entry["channel"] = gps["channel"]   # 2.4/5 GHz band on rescan
                     except Exception as e:
                         log.debug(f"[pwn-companion] Bad gps sidecar {gps_path}: {e}")
 

--- a/pwn-companion.py
+++ b/pwn-companion.py
@@ -143,7 +143,7 @@ class PwnagotchiEventBroadcaster:
                 "description": f"Captured {count} handshake{'s' if count != 1 else ''} from {network_name} ({security})"
             }
 
-            log.info(f"[pwn-companion]  AI Event: {event['description']}")
+            log.debug(f"[pwn-companion]  AI Event: {event['description']}")
             await self.send_to_app(event)
         except Exception as e:
             log.error(f"[pwn-companion] Error in on_handshakes_captured: {e}")
@@ -178,7 +178,7 @@ class PwnagotchiEventBroadcaster:
             }
 
             if is_new:
-                log.info(f"[pwn-companion]  AI Event: {event['description']}")
+                log.debug(f"[pwn-companion]  AI Event: {event['description']}")
                 await self.send_to_app(event)
         except Exception as e:
             log.error(f"[pwn-companion] Error in on_network_discovered: {e}")
@@ -201,7 +201,7 @@ class PwnagotchiEventBroadcaster:
                 "description": f"Successfully connected to {network_name}" + (f" in {duration:.1f}s" if duration > 0 else "")
             }
 
-            log.info(f"[pwn-companion]  AI Event: {event['description']}")
+            log.debug(f"[pwn-companion]  AI Event: {event['description']}")
             await self.send_to_app(event)
         except Exception as e:
             log.error(f"[pwn-companion] Error in on_connection_success: {e}")
@@ -281,7 +281,7 @@ class PwnagotchiEventBroadcaster:
                 "description": f"High-value target found: {network_name}" + (f" ({reason})" if reason else "")
             }
 
-            log.info(f"[pwn-companion]  AI Event: {event['description']}")
+            log.debug(f"[pwn-companion]  AI Event: {event['description']}")
             await self.send_to_app(event)
         except Exception as e:
             log.error(f"[pwn-companion] Error in on_high_value_target: {e}")
@@ -305,7 +305,7 @@ class PwnagotchiEventBroadcaster:
                 "description": f"Scan complete: Found {networks_found} networks" + (f" in {duration:.1f}s" if duration > 0 else "")
             }
 
-            log.info(f"[pwn-companion]  AI Event: {event['description']}")
+            log.debug(f"[pwn-companion]  AI Event: {event['description']}")
             await self.send_to_app(event)
         except Exception as e:
             log.error(f"[pwn-companion] Error in on_scan_complete: {e}")

--- a/pwn-companion.py
+++ b/pwn-companion.py
@@ -835,6 +835,10 @@ class PwnCompanion(Plugin):
             # Increment running total
             self._total_handshakes += 1
 
+            # Per-channel ground truth — attribute the capture to the AP's real channel
+            # (incl. 5 GHz), since epoch_data has none on modern pwnagotchi.
+            self._bump_channel_stat(ap_channel, "handshakes")
+
             # Fire AI network_event immediately — this is the main driver of AI responses
             if self.event_broadcaster and self.app_connected:
                 self._schedule_on_loop(
@@ -1212,7 +1216,8 @@ class PwnCompanion(Plugin):
             security = ap.get("encryption", "Unknown")
             bssid = ap.get("mac", None)
 
-            log.info(f"[pwn-companion]  Association: {ssid} CH{channel} ({rssi}dBm)")
+            self._bump_channel_stat(channel, "associations")
+            log.debug(f"[pwn-companion]  Association: {ssid} CH{channel} ({rssi}dBm)")
 
             if self.event_broadcaster and self.app_connected:
                 self._schedule_on_loop(
@@ -1235,6 +1240,7 @@ class PwnCompanion(Plugin):
             channel = ap.get("channel", 0) if isinstance(ap, dict) else 0
             ssid = (ap.get("hostname", "") or ap.get("essid", "")) if isinstance(ap, dict) else str(ap)
             bssid = (ap.get("mac", "") or ap.get("bssid", "")) if isinstance(ap, dict) else ""
+            self._bump_channel_stat(channel, "deauths")
             # The deauth TARGET is a client station MAC — previously ignored, which is why
             # the app's log line had nothing to show and fell back to "spectrum".
             sta_mac = station.get("mac", "") if isinstance(station, dict) else ""
@@ -1253,6 +1259,30 @@ class PwnCompanion(Plugin):
                 )
         except Exception as e:
             log.debug(f"[pwn-companion] Error in on_deauthentication: {e}")
+
+    def _bump_channel_stat(self, channel, key, n=1):
+        """Record per-channel ground truth keyed by the AP's REAL channel.
+
+        On pwnagotchi >= 2.9.5.5 epoch_data carries no channel, so this — driven off the
+        AP dict in on_handshake/on_association/on_deauthentication — is the only working
+        source of per-channel handshake/assoc/deauth counts (incl. 5 GHz). The app uses it
+        to steer toward the channels that actually yield.
+        """
+        try:
+            ch = int(channel)
+        except (TypeError, ValueError):
+            return
+        if not (1 <= ch <= 165):
+            return
+        with self.lock:
+            st = self._channel_stats.setdefault(
+                ch, {"handshakes": 0, "deauths": 0, "associations": 0, "aps": 0, "sta": 0}
+            )
+            st[key] = st.get(key, 0) + n
+            if key == "handshakes":
+                self._best_channel = max(
+                    self._channel_stats, key=lambda c: self._channel_stats[c]["handshakes"]
+                )
 
     def on_epoch(self, agent, epoch, epoch_data):
         """
@@ -1305,6 +1335,30 @@ class PwnCompanion(Plugin):
                     f"da={epoch_data.get('num_deauths',0)} "
                     f"as={epoch_data.get('num_associations',0)}"
                 )
+
+            # Per-channel target density from the live scan (epoch_data has no per-channel
+            # data on modern pwnagotchi). APs + clients per channel = the "clients here now"
+            # signal the app weights heavily for steering. Snapshot each epoch, not cumulative.
+            try:
+                aps = agent.get_access_points() or []
+                with self.lock:
+                    for st in self._channel_stats.values():
+                        st["aps"] = 0
+                        st["sta"] = 0
+                    for ap in aps:
+                        c = ap.get("channel") if isinstance(ap, dict) else None
+                        if not c:
+                            continue
+                        c = int(c)
+                        if not (1 <= c <= 165):
+                            continue
+                        st = self._channel_stats.setdefault(
+                            c, {"handshakes": 0, "deauths": 0, "associations": 0, "aps": 0, "sta": 0}
+                        )
+                        st["aps"] += 1
+                        st["sta"] += len(ap.get("clients", []) or [])
+            except Exception as e:
+                log.debug(f"[pwn-companion] per-channel density tally skipped: {e}")
 
             # Send autotune_stats to app if connected
             if self.app_connected and self._channel_stats:

--- a/pwn-companion.py
+++ b/pwn-companion.py
@@ -2463,11 +2463,15 @@ class PwnCompanion(Plugin):
     async def _send_autotune_stats(self, agent):
         """Push auto-tune channel efficiency stats to the app."""
         try:
-            if not self._channel_stats:
-                return
+            # supported_channels must go out even when there are NO per-channel stats:
+            # on modern pwnagotchi epoch_data has no channel, so _channel_stats stays
+            # empty forever — but the app still needs the supported list to steer 5 GHz.
+            supported = self._supported_channels(agent)
             # Snapshot under the lock — on_epoch mutates this on another thread.
             with self.lock:
                 channels_payload = {str(c): dict(v) for c, v in self._channel_stats.items()}
+            if not channels_payload and not supported:
+                return
             msg = {
                 "type": "autotune_stats",
                 "autotune_channels": channels_payload,
@@ -2478,7 +2482,6 @@ class PwnCompanion(Plugin):
             rssi = self._autotune_min_rssi()
             if rssi is not None:
                 msg["autotune_min_rssi"] = rssi
-            supported = self._supported_channels(agent)
             if supported:
                 msg["supported_channels"] = supported
             await self._send_to_app(msg)


### PR DESCRIPTION
Confirmed working on-device (MT7612U, pwnagotchi 2.9.5.9): steered sets are band-diverse and reach 5 GHz — e.g. 11,1,48 → 11,1,52 → 11,1,56 → 11,1,60 (exploit proven 2.4, explore 5 GHz).

## What was broken
Channel steering seeded candidates from a hardcoded 2.4 GHz floor, so dual-band adapters never discovered 5 GHz. Two further issues surfaced on modern pwnagotchi:
- epoch_data has no 'channel' key (>= 2.9.5.5 'strategy' core), so the plugin's per-channel autotune never populates → the app's old 'need autotune/learning to steer' gate blocked steering entirely.
- supported_channels was only attached to the autotune message, which bails when per-channel stats are empty (always, now) → it never reached the app → recon capped at ch11.

## Fix
- Plugin reports the monitor iface's supported_channels (reg-domain aware) and sends it even when per-channel stats are empty.
- App uses supported_channels as the candidate universe (fallback to the 2.4 floor when unknown; older plugins unaffected).
- Cold-start discovery steer: no longer requires autotune/learning — explores the supported channels immediately so recon covers both bands from cycle one.

versionCode 12 / 1.2.6.